### PR TITLE
Lift the snippet ceiling on the icons docs

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -67,6 +67,22 @@ export const metadata: Metadata = {
     // No `images` here: `app/opengraph-image.tsx` is the card. Next reuses it
     // for `twitter:image` too when there is no `twitter-image` file.
   },
+  // Without these, Google's defaults cap the text snippet and the image
+  // preview. The cap is what AI surfaces read against when deciding how much of
+  // a page they may quote, and Search Console shows those surfaces carrying 27%
+  // of blode.co's impressions over 28 days. blode.co sets these three at its
+  // root; no zone did.
+  robots: {
+    follow: true,
+    googleBot: {
+      follow: true,
+      index: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+    index: true,
+  },
   title: {
     default: siteTitle,
     template: "%s | Blode Icons",


### PR DESCRIPTION
Part of a Search Console audit across blode.co and its zones (28 days to 2026-08-16).

## What this changes

The zone shipped no `robots` directives, so Google's defaults applied: a capped text snippet and a thumbnail-sized image preview. That cap is what AI surfaces read against when deciding how much of a page they may quote, and Search Console puts those surfaces at **27% of blode.co's impressions** over the window.

blode.co sets `max-snippet:-1`, `max-image-preview:large` and `max-video-preview:-1` at its root. **No zone did**, so every proxied project was quoting-capped while the parent was not. Same one-block change as the other nine repos.

## Scope

Metadata only, one file: `apps/docs/app/layout.tsx`. No change to `packages/blode-icons-react`, so **no changeset** is needed.

## Verification

`npm run check:types` passes 3/3 tasks. Note it fails on a clean checkout until `npm run build` has run once, because `packages/blode-icons-react/src/index.ts` imports the generated `./all-icons`. That is build ordering, not this branch: it reproduces on `main`.

The build also rewrites `apps/docs/src/icons-tsx/*`. Those regenerated files were reverted and are not part of this PR, but the drift between committed and freshly generated output is worth a look separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSVzcpTXLzGvzu42LaM2ri)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only SEO directives in the docs layout; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Adds explicit **`robots`** metadata to the docs root layout so Google is told to index/follow and to allow **unlimited snippets**, **large image previews**, and **unlimited video previews**—matching what blode.co already sets at its root.
> 
> Previously the icons zone shipped no `robots` block, so Google’s default snippet and thumbnail caps applied; the change is metadata-only in `apps/docs/app/layout.tsx` with an inline comment tying it to Search Console / AI quoting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a645a0ee5c82c6c596667e2e6093835a9de4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->