### PR TITLE
docs(blode-icons-react): list get_usage on the published MCP contract

### DIFF
--- a/.changeset/sync-mcp-get-usage.md
+++ b/.changeset/sync-mcp-get-usage.md
@@ -1,0 +1,5 @@
+---
+"blode-icons-react": patch
+---
+
+List the hosted MCP `get_usage` tool in the published package README.

--- a/packages/blode-icons-react/README.md
+++ b/packages/blode-icons-react/README.md
@@ -73,7 +73,7 @@ All icons accept standard SVG attributes plus:
 ## Agents
 
 - Site: https://blode.co/icons
-- MCP: https://blode.co/icons/mcp (`search_icons`, `get_icon`)
+- MCP: https://blode.co/icons/mcp (`search_icons`, `get_icon`, `get_usage`)
 - `llms.txt`: https://blode.co/icons/llms.txt
 - shadcn registry: `npx shadcn@latest add https://blode.co/icons/r/<slug>.json`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The hosted MCP server at `blode.co/icons/mcp` registers three tools: `search_icons`, `get_icon`, and `get_usage` (`apps/docs/app/mcp/route.ts`). Every in-repo agent surface already lists all three (`llms.txt`, docs getting-started, skill reference, `siteConfig.toolNames`).

The published `blode-icons-react` README, which npm shows as the package landing page, still listed only `search_icons` and `get_icon`. Agents and humans copying that list miss `get_usage`.

**Authoritative source:** `apps/docs/app/mcp/route.ts` (`server.registerTool` order).

**Sync:** README tool list plus a patch changeset.

**Validation:** extracted `registerTool` names from the route and compared them to the README list (exact match). `git diff --check` clean. Docs-only; no runtime change.

**Compatibility:** Documentation-only. The tool already exists; this does not change the MCP or package API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1b23c13-6edb-4d99-bd11-e3570b4d6290?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1b23c13-6edb-4d99-bd11-e3570b4d6290&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

